### PR TITLE
Fix API URL configuration and update environment variables

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,4 @@
+# API Base URL
+# ローカル開発時は通常 http://localhost:3001 を使用
+# LAN経由でアクセスする場合は、APIサーバーのIPアドレスを指定
+VITE_API_URL=http://localhost:3001

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_BASE_URL: string;
+  readonly VITE_API_URL: string;
 }
 
 interface ImportMeta {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        target: "http://localhost:3001",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## 概要

APIサーバーのポート番号を3000から3001に変更し、環境変数の命名を統一しました。また、ローカル開発環境用の`.env.example`ファイルを追加しました。

## 関連するIssue

<!-- 関連するIssue番号があれば記載 -->

## 実装内容

- **環境変数の命名統一**: `VITE_API_BASE_URL` → `VITE_API_URL` に変更
- **APIサーバーポート更新**: `http://localhost:3000` → `http://localhost:3001` に変更
- **環境設定ファイル追加**: `.env.example`を追加し、開発環境のセットアップを容易に
- **型定義の更新**: `vite-env.d.ts`の環境変数型定義を更新

## 動作確認

- ローカル開発環境でAPIサーバー（ポート3001）への接続確認が必要
- LAN経由でのアクセス時に、`.env`ファイルでAPIサーバーのIPアドレスを指定できることを確認

## レビュー観点

- APIサーバーのポート番号変更が他の設定ファイルに影響していないか
- 環境変数の命名変更が全体で統一されているか
- `.env.example`のコメント（日本語）が適切か

## 未着手の項目

<!-- 今後実装する必要があるが、未着手のタスクを記載-->

## 補足事項

- `.env.example`には日本語でコメントを記載し、ローカル開発時とLAN経由アクセス時の使い分けを説明しています
- 実際の`.env`ファイルは`.gitignore`に含まれているため、各開発者が自身の環境に合わせて設定する必要があります

https://claude.ai/code/session_014woRqBoHyJV9DtdfSudGk7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/axelaspor2/curio/pull/29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
