### PR TITLE
Add db:generate step before building database package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         working-directory: apps
 
       - name: Build database package
-        run: pnpm --filter @curio/database build
+        run: pnpm --filter @curio/database db:generate && pnpm --filter @curio/database build
         working-directory: apps
 
       - name: Build API


### PR DESCRIPTION
## 概要

CI/CDパイプラインの database パッケージビルドステップに、`db:generate` コマンドの実行を追加しました。ビルド前にデータベース関連のコード生成を実行することで、ビルドの成功率を向上させます。

## 関連するIssue

<!-- 関連するIssue番号があれば記載 -->

## 実装内容

- **CI/CD改善**: `.github/workflows/ci.yml` の "Build database package" ステップを修正
- `pnpm --filter @curio/database build` の前に `pnpm --filter @curio/database db:generate` を実行するよう変更
- これにより、ビルド時に必要なコード生成が確実に完了した状態でビルドが開始されます

## 動作確認

- CI/CDパイプラインで database パッケージのビルドが正常に完了することを確認

## レビュー観点

- `db:generate` コマンドが正しく実行されるか
- ビルドステップの実行順序が適切か
- 他のパッケージのビルドに影響がないか

## 未着手の項目

<!-- 今後実装する必要があるが、未着手のタスクを記載-->

## 補足事項

このコマンド実行順序の変更により、database パッケージのビルドが確実に成功するようになります。

https://claude.ai/code/session_014XMzzNgUPpCMTrsypPwD8e
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/axelaspor2/curio/pull/30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
