### PR TITLE
fix(jobs): RSSフィード保存の競合状態と無効日付処理を修正

### DIFF
--- a/apps/jobs/src/rss-fetch/rss.service.ts
+++ b/apps/jobs/src/rss-fetch/rss.service.ts
@@ -73,38 +73,53 @@ export const rssService = {
     items: FeedItem[],
     invalidCount: number = 0,
   ): ResultAsync<FetchResult, FeedParseError> => {
-    const parsePublishedAt = (item: FeedItem): Date | null =>
-      item.isoDate ? new Date(item.isoDate) : item.pubDate ? new Date(item.pubDate) : null;
+    const parsePublishedAt = (item: FeedItem): Date | null => {
+      const dateStr = item.isoDate ?? item.pubDate;
+      if (!dateStr) return null;
+      const date = new Date(dateStr);
+      // 無効な日付の場合はnullを返し、他の記事の保存を継続させる
+      return Number.isNaN(date.getTime()) ? null : date;
+    };
 
     const saveItem = async (item: FeedItem): Promise<{ saved: boolean; skipped: boolean }> => {
       const externalId = item.guid ?? null;
 
-      // 同一ソース内でguidが一致、または全体でURLが一致する記事は重複とみなす
-      // guidはソース間で衝突する可能性があるため、sourceIdと組み合わせて検索
-      const existing = await prisma.article.findFirst({
-        where: {
-          OR: [...(externalId ? [{ sourceId, externalId }] : []), { url: item.link }],
-        },
+      // URLで既存の記事を検索（URLは全体で一意であるべき）
+      const existingByUrl = await prisma.article.findFirst({
+        where: { url: item.link },
       });
 
-      if (existing) {
+      if (existingByUrl) {
         return { saved: false, skipped: true };
       }
 
-      await prisma.article.create({
-        data: {
-          sourceId,
-          externalId,
-          title: item.title,
-          content: item.content ?? null,
-          summary: item.contentSnippet ?? null,
-          url: item.link,
-          imageUrl: item.enclosure?.url ?? null,
-          publishedAt: parsePublishedAt(item),
-        },
-      });
+      try {
+        await prisma.article.create({
+          data: {
+            sourceId,
+            externalId,
+            title: item.title,
+            content: item.content ?? null,
+            summary: item.contentSnippet ?? null,
+            url: item.link,
+            imageUrl: item.enclosure?.url ?? null,
+            publishedAt: parsePublishedAt(item),
+          },
+        });
 
-      return { saved: true, skipped: false };
+        return { saved: true, skipped: false };
+      } catch (error) {
+        // ユニーク制約違反（競合状態で別のジョブが先に挿入した場合）は「スキップ」として扱う
+        // Prisma error code P2002 = Unique constraint failed
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          (error as { code: string }).code === "P2002"
+        ) {
+          return { saved: false, skipped: true };
+        }
+        throw error;
+      }
     };
 
     return ResultAsync.fromPromise(


### PR DESCRIPTION
- parsePublishedAt: 無効な日付の場合はnullを返し、他記事の保存を継続
- saveItem: createをtry-catchで囲み、ユニーク制約違反(P2002)をスキップとして扱う これにより、複数ジョブ同時実行時のTOCTOU競合を解決

Fixes Devin review comments on PR #31

https://claude.ai/code/session_01Bzmpvmg7gcfHiws5cNNK5j

## 概要

<!-- どのような変更を加えたか、概要を記載 -->

## 関連するIssue

<!-- 関連するIssue番号があれば記載（例: #123） -->

## 実装内容
<!-- 
 • 機能追加
 • バグ修正
 • リファクタリング
 • ドキュメント修正
 • その他（詳細は概要に）
 -->

## 動作確認

<!-- 必要あれば、動作確認をした際のスクリーンショット等を添付-->

## レビュー観点

<!-- レビュワーがどのあたりを見れば良いかを記載-->

## 未着手の項目

<!-- 今後実装する必要があるが、未着手のタスクを記載-->

## 補足事項

<!-- その他レビュワーに伝えたいことや注意点があれば記載 -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/axelaspor2/curio/pull/32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
