### PR TITLE
ci(cd): CDパイプラインを構築

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,88 @@
+# ============================================================================
+# Curio Frontend Deployment to GitHub Pages
+# ============================================================================
+
+name: Deploy Web to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/web/**'
+      - 'apps/api/**'
+      - 'apps/packages/database/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: apps/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: apps
+
+      - name: Generate Prisma client
+        run: pnpm --filter @curio/database db:generate
+        working-directory: apps
+
+      - name: Build database package
+        run: pnpm --filter @curio/database build
+        working-directory: apps
+
+      - name: Build API (for types)
+        run: pnpm --filter @curio/api build
+        working-directory: apps
+
+      - name: Generate TanStack Router route tree
+        run: pnpm --filter @curio/web exec tsr generate
+        working-directory: apps
+
+      - name: Build Web
+        run: pnpm --filter @curio/web build
+        working-directory: apps
+        env:
+          VITE_API_URL: ${{ vars.VITE_API_URL }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/web/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,71 @@
+# ============================================================================
+# Curio API Dockerfile
+# Multi-stage build for production deployment to Cloud Run
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Stage 1: Builder
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS builder
+
+# Enable corepack for pnpm
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+# Copy workspace configuration files
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+
+# Copy package.json files for dependency resolution
+COPY packages/database/package.json ./packages/database/
+COPY api/package.json ./api/
+
+# Install all dependencies (including devDependencies for build)
+RUN pnpm install --frozen-lockfile
+
+# Copy source files
+COPY packages/database ./packages/database
+COPY api ./api
+
+# Generate Prisma client and build database package
+WORKDIR /app/packages/database
+RUN pnpm db:generate && pnpm build
+
+# Build API
+WORKDIR /app/api
+RUN pnpm build
+
+# ----------------------------------------------------------------------------
+# Stage 2: Runner (Production)
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS runner
+
+# Enable corepack for pnpm
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+# Set production environment
+ENV NODE_ENV=production
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+
+# Copy package.json files
+COPY packages/database/package.json ./packages/database/
+COPY api/package.json ./api/
+
+# Install production dependencies only
+RUN pnpm install --frozen-lockfile --prod
+
+# Copy built artifacts from builder stage
+COPY --from=builder /app/packages/database/dist ./packages/database/dist
+COPY --from=builder /app/packages/database/prisma ./packages/database/prisma
+COPY --from=builder /app/api/dist ./api/dist
+
+# Cloud Run uses PORT environment variable (default: 8080)
+ENV PORT=8080
+EXPOSE 8080
+
+# Run the API server
+CMD ["node", "api/dist/index.js"]

--- a/apps/jobs/article-enrichment.Dockerfile
+++ b/apps/jobs/article-enrichment.Dockerfile
@@ -1,0 +1,59 @@
+# ============================================================================
+# Curio Article Enrichment Job Dockerfile
+# Cloud Run Jobs for LLM processing (classification, summarization, embedding)
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Stage 1: Builder
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+COPY jobs/package.json ./jobs/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source files
+COPY packages/database ./packages/database
+COPY jobs ./jobs
+
+# Generate Prisma client and build
+WORKDIR /app/packages/database
+RUN pnpm db:generate && pnpm build
+
+WORKDIR /app/jobs
+RUN pnpm build
+
+# ----------------------------------------------------------------------------
+# Stage 2: Runner
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS runner
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+COPY jobs/package.json ./jobs/
+
+# Install production dependencies
+RUN pnpm install --frozen-lockfile --prod
+
+# Copy built artifacts
+COPY --from=builder /app/packages/database/dist ./packages/database/dist
+COPY --from=builder /app/packages/database/prisma ./packages/database/prisma
+COPY --from=builder /app/jobs/dist ./jobs/dist
+
+# Run article enrichment job
+CMD ["node", "jobs/dist/article-enrichment/index.js"]

--- a/apps/jobs/article-fetch.Dockerfile
+++ b/apps/jobs/article-fetch.Dockerfile
@@ -1,0 +1,59 @@
+# ============================================================================
+# Curio Article Fetch Job Dockerfile
+# Cloud Run Jobs for fetching article content
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Stage 1: Builder
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+COPY jobs/package.json ./jobs/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source files
+COPY packages/database ./packages/database
+COPY jobs ./jobs
+
+# Generate Prisma client and build
+WORKDIR /app/packages/database
+RUN pnpm db:generate && pnpm build
+
+WORKDIR /app/jobs
+RUN pnpm build
+
+# ----------------------------------------------------------------------------
+# Stage 2: Runner
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS runner
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+COPY jobs/package.json ./jobs/
+
+# Install production dependencies
+RUN pnpm install --frozen-lockfile --prod
+
+# Copy built artifacts
+COPY --from=builder /app/packages/database/dist ./packages/database/dist
+COPY --from=builder /app/packages/database/prisma ./packages/database/prisma
+COPY --from=builder /app/jobs/dist ./jobs/dist
+
+# Run article fetch job
+CMD ["node", "jobs/dist/article-fetch/index.js"]

--- a/apps/jobs/db-migrate.Dockerfile
+++ b/apps/jobs/db-migrate.Dockerfile
@@ -1,0 +1,54 @@
+# ============================================================================
+# Curio DB Migration Job Dockerfile
+# Cloud Run Jobs for running Prisma migrations
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Stage 1: Builder
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+
+# Install dependencies (need devDependencies for prisma CLI)
+RUN pnpm install --frozen-lockfile
+
+# Copy database package
+COPY packages/database ./packages/database
+
+# Generate Prisma client
+WORKDIR /app/packages/database
+RUN pnpm db:generate
+
+# ----------------------------------------------------------------------------
+# Stage 2: Runner
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS runner
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+
+# Install all dependencies (prisma CLI is in devDependencies)
+RUN pnpm install --frozen-lockfile
+
+# Copy Prisma schema and migrations
+COPY --from=builder /app/packages/database/prisma ./packages/database/prisma
+COPY --from=builder /app/packages/database/node_modules/.prisma ./packages/database/node_modules/.prisma
+
+WORKDIR /app/packages/database
+
+# Run database migration
+CMD ["pnpm", "db:migrate:deploy"]

--- a/apps/jobs/interest-vector.Dockerfile
+++ b/apps/jobs/interest-vector.Dockerfile
@@ -1,0 +1,59 @@
+# ============================================================================
+# Curio Interest Vector Job Dockerfile
+# Cloud Run Jobs for calculating user interest vectors
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Stage 1: Builder
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+COPY jobs/package.json ./jobs/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source files
+COPY packages/database ./packages/database
+COPY jobs ./jobs
+
+# Generate Prisma client and build
+WORKDIR /app/packages/database
+RUN pnpm db:generate && pnpm build
+
+WORKDIR /app/jobs
+RUN pnpm build
+
+# ----------------------------------------------------------------------------
+# Stage 2: Runner
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS runner
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+COPY jobs/package.json ./jobs/
+
+# Install production dependencies
+RUN pnpm install --frozen-lockfile --prod
+
+# Copy built artifacts
+COPY --from=builder /app/packages/database/dist ./packages/database/dist
+COPY --from=builder /app/packages/database/prisma ./packages/database/prisma
+COPY --from=builder /app/jobs/dist ./jobs/dist
+
+# Run interest vector job
+CMD ["node", "jobs/dist/interest-vector/index.js"]

--- a/apps/jobs/rss-fetch.Dockerfile
+++ b/apps/jobs/rss-fetch.Dockerfile
@@ -1,0 +1,59 @@
+# ============================================================================
+# Curio RSS Fetch Job Dockerfile
+# Cloud Run Jobs for fetching RSS feeds
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Stage 1: Builder
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+COPY jobs/package.json ./jobs/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source files
+COPY packages/database ./packages/database
+COPY jobs ./jobs
+
+# Generate Prisma client and build
+WORKDIR /app/packages/database
+RUN pnpm db:generate && pnpm build
+
+WORKDIR /app/jobs
+RUN pnpm build
+
+# ----------------------------------------------------------------------------
+# Stage 2: Runner
+# ----------------------------------------------------------------------------
+FROM node:24-slim AS runner
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/database/package.json ./packages/database/
+COPY jobs/package.json ./jobs/
+
+# Install production dependencies
+RUN pnpm install --frozen-lockfile --prod
+
+# Copy built artifacts
+COPY --from=builder /app/packages/database/dist ./packages/database/dist
+COPY --from=builder /app/packages/database/prisma ./packages/database/prisma
+COPY --from=builder /app/jobs/dist ./jobs/dist
+
+# Run RSS fetch job
+CMD ["node", "jobs/dist/rss-fetch/index.js"]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,8 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  // GitHub Pages deployment: use /curio/ as base path
+  base: process.env.GITHUB_ACTIONS ? "/curio/" : "/",
   plugins: [TanStackRouterVite({ autoCodeSplitting: true }), react(), tailwindcss()],
   resolve: {
     alias: {

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,329 @@
+# ============================================================================
+# Curio CD Pipeline - Cloud Build Configuration
+# Deploys API to Cloud Run, Jobs to Cloud Run Jobs, and runs DB migrations
+# ============================================================================
+
+substitutions:
+  _REGION: asia-northeast1
+  _ARTIFACT_REGISTRY: curio
+  _CLOUD_SQL_INSTANCE: team-aizawa:asia-northeast1:curio-prod
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: E2_HIGHCPU_8
+
+# ============================================================================
+# Build Steps
+# ============================================================================
+steps:
+  # --------------------------------------------------------------------------
+  # Step 1: Build all images in parallel
+  # --------------------------------------------------------------------------
+
+  # Build API image
+  - id: 'build-api'
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-api:${SHORT_SHA}'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-api:latest'
+      - '-f'
+      - 'apps/api/Dockerfile'
+      - 'apps'
+
+  # Build RSS Fetch job image
+  - id: 'build-rss-fetch'
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-rss-fetch:${SHORT_SHA}'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-rss-fetch:latest'
+      - '-f'
+      - 'apps/jobs/rss-fetch.Dockerfile'
+      - 'apps'
+
+  # Build Article Fetch job image
+  - id: 'build-article-fetch'
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-fetch:${SHORT_SHA}'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-fetch:latest'
+      - '-f'
+      - 'apps/jobs/article-fetch.Dockerfile'
+      - 'apps'
+
+  # Build Article Enrichment job image
+  - id: 'build-article-enrichment'
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-enrichment:${SHORT_SHA}'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-enrichment:latest'
+      - '-f'
+      - 'apps/jobs/article-enrichment.Dockerfile'
+      - 'apps'
+
+  # Build Interest Vector job image
+  - id: 'build-interest-vector'
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-interest-vector:${SHORT_SHA}'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-interest-vector:latest'
+      - '-f'
+      - 'apps/jobs/interest-vector.Dockerfile'
+      - 'apps'
+
+  # Build DB Migrate job image
+  - id: 'build-db-migrate'
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-db-migrate:${SHORT_SHA}'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-db-migrate:latest'
+      - '-f'
+      - 'apps/jobs/db-migrate.Dockerfile'
+      - 'apps'
+
+  # --------------------------------------------------------------------------
+  # Step 2: Push all images to Artifact Registry
+  # --------------------------------------------------------------------------
+
+  - id: 'push-api'
+    name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-api']
+    waitFor: ['build-api']
+
+  - id: 'push-rss-fetch'
+    name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-rss-fetch']
+    waitFor: ['build-rss-fetch']
+
+  - id: 'push-article-fetch'
+    name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-fetch']
+    waitFor: ['build-article-fetch']
+
+  - id: 'push-article-enrichment'
+    name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-enrichment']
+    waitFor: ['build-article-enrichment']
+
+  - id: 'push-interest-vector'
+    name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-interest-vector']
+    waitFor: ['build-interest-vector']
+
+  - id: 'push-db-migrate'
+    name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-db-migrate']
+    waitFor: ['build-db-migrate']
+
+  # --------------------------------------------------------------------------
+  # Step 3: Deploy DB Migration Job and Run Migration
+  # --------------------------------------------------------------------------
+
+  - id: 'deploy-db-migrate-job'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'jobs'
+      - 'deploy'
+      - 'curio-db-migrate'
+      - '--image'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-db-migrate:${SHORT_SHA}'
+      - '--region'
+      - '${_REGION}'
+      - '--add-cloudsql-instances'
+      - '${_CLOUD_SQL_INSTANCE}'
+      - '--set-secrets'
+      - 'DATABASE_URL=curio-database-url:latest'
+      - '--memory'
+      - '256Mi'
+      - '--task-timeout'
+      - '300s'
+    waitFor: ['push-db-migrate']
+
+  - id: 'run-db-migrate'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'jobs'
+      - 'execute'
+      - 'curio-db-migrate'
+      - '--region'
+      - '${_REGION}'
+      - '--wait'
+    waitFor: ['deploy-db-migrate-job']
+
+  # --------------------------------------------------------------------------
+  # Step 4: Deploy API to Cloud Run
+  # --------------------------------------------------------------------------
+
+  - id: 'deploy-api'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'curio-api'
+      - '--image'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-api:${SHORT_SHA}'
+      - '--region'
+      - '${_REGION}'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+      - '--add-cloudsql-instances'
+      - '${_CLOUD_SQL_INSTANCE}'
+      - '--set-secrets'
+      - 'DATABASE_URL=curio-database-url:latest,BETTER_AUTH_SECRET=curio-auth-secret:latest'
+      - '--set-env-vars'
+      - 'NODE_ENV=production,BETTER_AUTH_URL=https://curio-api-${PROJECT_NUMBER}-an.a.run.app,CORS_ORIGINS=https://axelaspor2.github.io'
+      - '--memory'
+      - '512Mi'
+      - '--cpu'
+      - '1'
+      - '--min-instances'
+      - '0'
+      - '--max-instances'
+      - '10'
+    waitFor: ['push-api', 'run-db-migrate']
+
+  # --------------------------------------------------------------------------
+  # Step 5: Deploy Cloud Run Jobs
+  # --------------------------------------------------------------------------
+
+  # RSS Fetch Job
+  - id: 'deploy-rss-fetch'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'jobs'
+      - 'deploy'
+      - 'curio-rss-fetch'
+      - '--image'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-rss-fetch:${SHORT_SHA}'
+      - '--region'
+      - '${_REGION}'
+      - '--add-cloudsql-instances'
+      - '${_CLOUD_SQL_INSTANCE}'
+      - '--set-secrets'
+      - 'DATABASE_URL=curio-database-url:latest'
+      - '--set-env-vars'
+      - 'NODE_ENV=production,LOG_LEVEL=info'
+      - '--memory'
+      - '512Mi'
+      - '--task-timeout'
+      - '300s'
+    waitFor: ['push-rss-fetch', 'run-db-migrate']
+
+  # Article Fetch Job
+  - id: 'deploy-article-fetch'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'jobs'
+      - 'deploy'
+      - 'curio-article-fetch'
+      - '--image'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-fetch:${SHORT_SHA}'
+      - '--region'
+      - '${_REGION}'
+      - '--add-cloudsql-instances'
+      - '${_CLOUD_SQL_INSTANCE}'
+      - '--set-secrets'
+      - 'DATABASE_URL=curio-database-url:latest'
+      - '--set-env-vars'
+      - 'NODE_ENV=production,LOG_LEVEL=info'
+      - '--memory'
+      - '512Mi'
+      - '--task-timeout'
+      - '600s'
+    waitFor: ['push-article-fetch', 'run-db-migrate']
+
+  # Article Enrichment Job
+  - id: 'deploy-article-enrichment'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'jobs'
+      - 'deploy'
+      - 'curio-article-enrichment'
+      - '--image'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-enrichment:${SHORT_SHA}'
+      - '--region'
+      - '${_REGION}'
+      - '--add-cloudsql-instances'
+      - '${_CLOUD_SQL_INSTANCE}'
+      - '--set-secrets'
+      - 'DATABASE_URL=curio-database-url:latest'
+      - '--set-env-vars'
+      - 'NODE_ENV=production,LOG_LEVEL=info,GOOGLE_CLOUD_PROJECT=${PROJECT_ID},GOOGLE_CLOUD_LOCATION=${_REGION}'
+      - '--memory'
+      - '1Gi'
+      - '--task-timeout'
+      - '1800s'
+    waitFor: ['push-article-enrichment', 'run-db-migrate']
+
+  # Interest Vector Job
+  - id: 'deploy-interest-vector'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'jobs'
+      - 'deploy'
+      - 'curio-interest-vector'
+      - '--image'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-interest-vector:${SHORT_SHA}'
+      - '--region'
+      - '${_REGION}'
+      - '--add-cloudsql-instances'
+      - '${_CLOUD_SQL_INSTANCE}'
+      - '--set-secrets'
+      - 'DATABASE_URL=curio-database-url:latest'
+      - '--set-env-vars'
+      - 'NODE_ENV=production,LOG_LEVEL=info,GOOGLE_CLOUD_PROJECT=${PROJECT_ID},GOOGLE_CLOUD_LOCATION=${_REGION}'
+      - '--memory'
+      - '1Gi'
+      - '--task-timeout'
+      - '1800s'
+    waitFor: ['push-interest-vector', 'run-db-migrate']
+
+# ============================================================================
+# Images to be stored in Artifact Registry
+# ============================================================================
+images:
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-api:${SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-api:latest'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-rss-fetch:${SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-rss-fetch:latest'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-fetch:${SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-fetch:latest'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-enrichment:${SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-article-enrichment:latest'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-interest-vector:${SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-interest-vector:latest'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-db-migrate:${SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/curio-db-migrate:latest'
+
+timeout: 2400s


### PR DESCRIPTION
## 概要

Cloud Build と GitHub Actions を使用した CD パイプラインを構築。

## 関連するIssue

なし

## 実装内容

### Cloud Build（バックエンド）
- API 用 Dockerfile（Cloud Run デプロイ）
- ジョブ用 Dockerfile 5種（Cloud Run Jobs デプロイ）
  - rss-fetch
  - article-fetch
  - article-enrichment
  - interest-vector
  - db-migrate
- `cloudbuild.yaml` でビルド・マイグレーション・デプロイを自動化

### GitHub Actions（フロントエンド）
- `deploy-web.yml` で GitHub Pages にデプロイ
- `vite.config.ts` に base path 設定を追加

## 動作確認

- [ ] ローカルで Dockerfile のビルドを確認
- [ ] Cloud Build トリガーの設定
- [ ] GitHub Actions の実行確認

## レビュー観点

- Dockerfile のマルチステージビルド構成
- cloudbuild.yaml の実行順序と依存関係
- 環境変数・シークレットの設定

## 未着手の項目

以下は手動設定が必要:
- Secret Manager にシークレット登録（`curio-database-url`, `curio-auth-secret`）
- Cloud Build サービスアカウントへの権限付与
- Cloud Build トリガー設定
- GitHub リポジトリに `VITE_API_URL` 変数を追加
- Cloud Scheduler 設定

## 補足事項

計画ファイル: `.claude/plans/keen-fluttering-cookie.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/axelaspor2/curio/pull/35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
